### PR TITLE
Add missing type error message

### DIFF
--- a/src/HotChocolate/Core/src/Types/Configuration/TypeInitializer.cs
+++ b/src/HotChocolate/Core/src/Types/Configuration/TypeInitializer.cs
@@ -456,9 +456,20 @@ internal class TypeInitializer
 
                 IReadOnlyList<ITypeReference> needed =
                     TryNormalizeDependencies(type.Conditionals,
-                        out IReadOnlyList<ITypeReference>? normalized)
+                        out IReadOnlyList<ITypeReference>? normalized,
+                        out IReadOnlyList<ITypeReference>? notFound)
                         ? normalized.Except(processed).ToArray()
                         : type.Conditionals.Select(t => t.TypeReference).ToArray();
+
+                if (notFound != null)
+                {
+                    _errors.Add(SchemaErrorBuilder.New()
+                        .SetMessage(
+                            TypeInitializer_CannotFindType,
+                            string.Join(", ", notFound.Reverse()))
+                        .SetTypeSystemObject(type.Type)
+                        .Build());
+                }
 
                 _errors.Add(SchemaErrorBuilder.New()
                     .SetMessage(
@@ -510,7 +521,9 @@ internal class TypeInitializer
     {
         foreach (RegisteredType type in _next)
         {
-            if (TryNormalizeDependencies(type.Conditionals, out IReadOnlyList<ITypeReference>? normalized) &&
+            if (TryNormalizeDependencies(type.Conditionals,
+                    out IReadOnlyList<ITypeReference>? normalized,
+                    out IReadOnlyList<ITypeReference>? _) &&
                 processed.IsSupersetOf(GetTypeRefsExceptSelfRefs(type, normalized)))
             {
                 yield return type;
@@ -551,7 +564,8 @@ internal class TypeInitializer
 
     private bool TryNormalizeDependencies(
         List<TypeDependency> dependencies,
-        [NotNullWhen(true)] out IReadOnlyList<ITypeReference>? normalized)
+        [NotNullWhen(true)] out IReadOnlyList<ITypeReference>? normalized,
+        [NotNullWhen(false)] out IReadOnlyList<ITypeReference>? notFound)
     {
         var n = new List<ITypeReference>();
 
@@ -562,6 +576,8 @@ internal class TypeInitializer
                 out ITypeReference? nr))
             {
                 normalized = null;
+                n.Add(dependency.TypeReference);
+                notFound = n;
                 return false;
             }
 
@@ -572,6 +588,7 @@ internal class TypeInitializer
         }
 
         normalized = n;
+        notFound = null;
         return true;
     }
 

--- a/src/HotChocolate/Core/src/Types/Properties/TypeResources.Designer.cs
+++ b/src/HotChocolate/Core/src/Types/Properties/TypeResources.Designer.cs
@@ -1460,5 +1460,11 @@ namespace HotChocolate.Properties {
                 return ResourceManager.GetString("ReflectionUtils_ExtractMethod_MethodExpected", resourceCulture);
             }
         }
+
+        internal static string TypeInitializer_CannotFindType {
+            get {
+                return ResourceManager.GetString("TypeInitializer_CannotFindType", resourceCulture);
+            }
+        }
     }
 }

--- a/src/HotChocolate/Core/src/Types/Properties/TypeResources.resx
+++ b/src/HotChocolate/Core/src/Types/Properties/TypeResources.resx
@@ -840,4 +840,7 @@ Type: `{0}`</value>
   <data name="ReflectionUtils_ExtractMethod_MethodExpected" xml:space="preserve">
     <value>Member is not a method!</value>
   </data>
+  <data name="TypeInitializer_CannotFindType" xml:space="preserve">
+    <value>Unable to find type(s) {0}</value>
+  </data>
 </root>


### PR DESCRIPTION
Add a more concise message when stitching errors occur

- Added a new list of `<ITypeReference>` for items not found
- If this list is not empty, then add an error

This results in the first error message to simply be:
`Unable to find type(s)  [AuditLogEntitySortInput123!] (HotChocolate.Types.ObjectType)`

Closes #5345
