### PR TITLE
Small POC "workaround"

### DIFF
--- a/src/HotChocolate/Stitching/src/Stitching.Redis/DependencyInjection/HotChocolateStitchingRedisRequestExecutorBuilderExtensions.cs
+++ b/src/HotChocolate/Stitching/src/Stitching.Redis/DependencyInjection/HotChocolateStitchingRedisRequestExecutorBuilderExtensions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using HotChocolate;
 using HotChocolate.Execution.Configuration;
@@ -13,7 +14,8 @@ namespace Microsoft.Extensions.DependencyInjection
         public static IRequestExecutorBuilder AddRemoteSchemasFromRedis(
             this IRequestExecutorBuilder builder,
             NameString configurationName,
-            Func<IServiceProvider, IConnectionMultiplexer> connectionFactory)
+            Func<IServiceProvider, IConnectionMultiplexer> connectionFactory,
+            List<string>? schemasConfigured = null)
         {
             if (connectionFactory is null)
             {
@@ -28,7 +30,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 IDatabase database = connection.GetDatabase();
                 ISubscriber subscriber = connection.GetSubscriber();
                 return new RedisExecutorOptionsProvider(
-                    builder.Name, configurationName, database, subscriber);
+                    builder.Name, configurationName, database, subscriber, schemasConfigured);
             });
 
             // Last but not least, we will setup the stitching context which will

--- a/src/HotChocolate/Stitching/src/Stitching.Redis/DependencyInjection/HotChocolateStitchingRedisRequestExecutorBuilderExtensions.cs
+++ b/src/HotChocolate/Stitching/src/Stitching.Redis/DependencyInjection/HotChocolateStitchingRedisRequestExecutorBuilderExtensions.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Extensions.DependencyInjection
             this IRequestExecutorBuilder builder,
             NameString configurationName,
             Func<IServiceProvider, IConnectionMultiplexer> connectionFactory,
-            List<string>? schemasConfigured = null)
+            List<string> schemasConfigured)
         {
             if (connectionFactory is null)
             {

--- a/src/HotChocolate/Stitching/src/Stitching/DependencyInjection/HotChocolateStitchingRequestExecutorExtensions.cs
+++ b/src/HotChocolate/Stitching/src/Stitching/DependencyInjection/HotChocolateStitchingRequestExecutorExtensions.cs
@@ -19,6 +19,7 @@ using HotChocolate.Stitching.Pipeline;
 using HotChocolate.Stitching.Requests;
 using HotChocolate.Stitching.SchemaDefinitions;
 using HotChocolate.Stitching.Utilities;
+using HotChocolate.Types;
 using HotChocolate.Utilities;
 using HotChocolate.Utilities.Introspection;
 using static HotChocolate.Stitching.ThrowHelper;

--- a/src/HotChocolate/Stitching/test/Stitching.Tests/Integration/FederatedRedisSchemaTests.cs
+++ b/src/HotChocolate/Stitching/test/Stitching.Tests/Integration/FederatedRedisSchemaTests.cs
@@ -32,6 +32,7 @@ namespace HotChocolate.Stitching.Integration
         private const string _inventory = "inventory";
         private const string _products = "products";
         private const string _reviews = "reviews";
+        private List<string> _schemas = new() { "accounts", "inventory", "products", "reviews" };
 
         private readonly ConnectionMultiplexer _connection;
 
@@ -68,7 +69,7 @@ namespace HotChocolate.Stitching.Integration
                     .AddSingleton(httpClientFactory)
                     .AddGraphQL()
                     .AddQueryType(d => d.Name("Query"))
-                    .AddRemoteSchemasFromRedis(configurationName, _ => _connection)
+                    .AddRemoteSchemasFromRedis(configurationName, _ => _connection, _schemas)
                     .ModifyOptions(o => o.SortFieldsByName = true)
                     .BuildSchemaAsync(cancellationToken: cts.Token);
 
@@ -101,7 +102,7 @@ namespace HotChocolate.Stitching.Integration
                     .AddSingleton(httpClientFactory)
                     .AddGraphQL()
                     .AddQueryType(d => d.Name("Query"))
-                    .AddRemoteSchemasFromRedis(configurationName, _ => _connection)
+                    .AddRemoteSchemasFromRedis(configurationName, _ => _connection, _schemas)
                     .Services
                     .BuildServiceProvider()
                     .GetRequiredService<IRequestExecutorResolver>();
@@ -167,7 +168,7 @@ namespace HotChocolate.Stitching.Integration
                     .AddSingleton(httpClientFactory)
                     .AddGraphQL()
                     .AddQueryType(d => d.Name("Query").Field("foo").Resolve("foo"))
-                    .AddRemoteSchemasFromRedis(configurationName, _ => _connection)
+                    .AddRemoteSchemasFromRedis(configurationName, _ => _connection, _schemas)
                     .Services
                     .BuildServiceProvider();
 
@@ -249,7 +250,7 @@ namespace HotChocolate.Stitching.Integration
                     .AddSingleton(httpClientFactory)
                     .AddGraphQL()
                     .AddQueryType(d => d.Name("Query"))
-                    .AddRemoteSchemasFromRedis(configurationName, _ => _connection)
+                    .AddRemoteSchemasFromRedis(configurationName, _ => _connection, _schemas)
                     .BuildRequestExecutorAsync(cancellationToken: cts.Token);
 
             // act
@@ -298,7 +299,7 @@ namespace HotChocolate.Stitching.Integration
                         .AddSingleton(httpClientFactory)
                         .AddGraphQL(configurationName)
                         .AddQueryType(d => d.Name("Query").Field("local").Resolve("I am local."))
-                        .AddRemoteSchemasFromRedis(configurationName, _ => _connection)
+                        .AddRemoteSchemasFromRedis(configurationName, _ => _connection, _schemas)
                         .BuildRequestExecutorAsync(configurationName, ct);
 
                 // act


### PR DESCRIPTION
Added a list of "known" schemas to the gateway (by known I mean configured, with an http client pointing at an API)
If the schema does not exist, the idea is that it doesn't incorporate it and doesn't give this error with the Uuid! not known.